### PR TITLE
chore: remove unneeded done callbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 env:
   CI: true

--- a/test/index.js
+++ b/test/index.js
@@ -4,50 +4,45 @@ const assert = require('assert')
 // npm modules
 const fixtures = require('haraka-test-fixtures')
 
-beforeEach((done) => {
+beforeEach(() => {
   this.plugin = new fixtures.plugin('dcc')
-  done() // if a test hangs, assure you called done()
 })
 
 describe('dcc', () => {
-  it('loads', (done) => {
+  it('loads', () => {
     assert.ok(this.plugin)
-    done()
   })
 })
 
 describe('load_dcc_ini', () => {
-  beforeEach((done) => {
+  beforeEach(() => {
     this.plugin = new fixtures.plugin('dcc')
     this.plugin.load_dcc_ini()
-    done()
   })
 
-  it('loads dcc.ini from config/dcc.ini', (done) => {
+  it('loads dcc.ini from config/dcc.ini', () => {
     assert.ok(this.plugin.cfg.main)
-    done()
   })
 
-  it('detects set path', (done) => {
+  it('detects set path', () => {
     assert.equal(
       this.plugin.cfg.dccifd.path,
       '/var/dcc/dccifd',
       this.plugin.cfg,
     )
-    done()
+
   })
 })
 
 describe('get_host', () => {
   ;['Unknown', 'NXDOMAIN', 'DNSERROR', undefined].forEach((e) => {
-    it(`returns undefined for ${e}`, (done) => {
+    it(`returns undefined for ${e}`, () => {
       assert.equal(this.plugin.get_host(e), undefined)
-      done()
     })
   })
 
-  it('returns a hostname', (done) => {
+  it('returns a hostname', () => {
     assert.equal(this.plugin.get_host('host'), 'host')
-    done()
+
   })
 })


### PR DESCRIPTION
Remove unnecessary done callbacks from tests:
- Remove synchronous done callbacks from beforeEach hooks
- Remove synchronous done callbacks from simple assert tests
- Tests with only synchronous assertions don't need done callbacks